### PR TITLE
build: Refactor to use Duo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 components/
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,35 @@
 
-build: components
-	component build
+BIN := node_modules/.bin
+JS = index.js
+CSS = frame.css
+TEMPLATE = template.html
+C8 = component.json
+JS_SRC = $(JS) $(TEMPLATE) $(C8)
 
-components:
-	component install
+build: build/build.js build/build.css
 
-dist: components
-	component build -o . -s SlantFrame -n slant-frame
+dist: slant-frame.js slant-frame.css
 
-.PHONY: build
+build/build.js: node_modules $(JS_SRC)
+	@mkdir -p $(dir $@)
+	@$(BIN)/duo --type js --development < index.js > $@
+
+build/build.css: node_modules $(CSS)
+	@mkdir -p $(dir $@)
+	@$(BIN)/duo --type css < frame.css > $@
+
+slant-frame.js: node_modules $(JS_SRC)
+	@$(BIN)/duo --type js --global SlantFrame < index.js > $@
+
+slant-frame.css: node_modules $(CSS)
+	@$(BIN)/duo --type css < frame.css > $@
+
+node_modules: package.json
+	@npm install
+	@touch $@
+
+clean:
+	rm -rf build components
+	rm -f slant-frame.css slant-frame.js
+
+.PHONY: dist clean

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "slant-frame",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "duo": "^0.8.10"
+  }
+}

--- a/slant-frame.css
+++ b/slant-frame.css
@@ -22,5 +22,3 @@
   margin: 0 auto;
   padding: 0;
 }
-
-


### PR DESCRIPTION
My initial goal here was to not require a global installation of
component@1.  I thought about just converting the Makefile to use a
local copy (`node_modules/.bin/component-*`), but made a biased
decision to use Duo (Duo is better).

This patch reopens then closes #1. :p

---

Breakdown of changes:

**Makefile**:
- rewrite to actually utilise `mtime`, etc
- use local duo(1) rather than global component(1)
- add a `node_modules` target

**package.json**:
- add Duo as a development dep
- use the `private` flag to prevent accidental publishing

**slant-frame.{css,js}**:
- rebuild

**.gitignore**:
- ignore node_modules
