### PR TITLE
index: Add use three-canvas-renderer for non-WebGL browsers

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,15 +2,22 @@
   "name": "slant-frame",
   "version": "0.1.3",
   "description": "Core video frame API for slant",
-  "scripts": ["index.js"],
-  "styles": ["frame.css"],
-  "templates": ["template.html"],
+  "scripts": [
+    "index.js"
+  ],
+  "styles": [
+    "frame.css"
+  ],
+  "templates": [
+    "template.html"
+  ],
   "dependencies": {
     "components/three.js": "*",
     "component/emitter": "*",
     "component/events": "*",
     "component/domify": "*",
     "component/raf": "*",
-    "jb55/has-webgl": "*"
+    "jb55/has-webgl": "*",
+    "littlstar/three-canvas-renderer": "*"
   }
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,9 @@ var three = require('three.js')
   , hasWebGL = require('has-webgl')
   , tpl = require('./template.html')
 
+// add three.CanvasRenderer
+require('three-canvas-renderer')(three);
+
 // default field of view
 var DEFAULT_FOV = 35;
 


### PR DESCRIPTION
Closes #2.
