### PR TITLE
fixed small bug with player state in fullscreen

### DIFF
--- a/dist/axis.js
+++ b/dist/axis.js
@@ -663,7 +663,6 @@ Axis.prototype.onfullscreenchange = function(fullscreen) {
   this.state.focused = true;
   this.state.animating = false;
   if (fullscreen) {
-    this.state.fullscreen = true;
     this.emit('enterfullscreen');
   } else {
     if (this.state.vr) {
@@ -982,6 +981,7 @@ Axis.prototype.fullscreen = function () {
     this.size(newWidth, newHeight);
   }
 
+  this.state.fullscreen = true;
   fullscreen(this.renderer.domElement, opts);
 };
 

--- a/index.js
+++ b/index.js
@@ -575,7 +575,6 @@ Axis.prototype.onfullscreenchange = function(fullscreen) {
   this.state.focused = true;
   this.state.animating = false;
   if (fullscreen) {
-    this.state.fullscreen = true;
     this.emit('enterfullscreen');
   } else {
     if (this.state.vr) {
@@ -894,6 +893,7 @@ Axis.prototype.fullscreen = function () {
     this.size(newWidth, newHeight);
   }
 
+  this.state.fullscreen = true;
   fullscreen(this.renderer.domElement, opts);
 };
 


### PR DESCRIPTION
@jwerle 

this fixes the bug where fullscreen didn't work on my weird monitors.  changing where I set the state I locks the onresize event from happening when it wasn't supposed to.